### PR TITLE
ci: add security analysis workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,12 +5,12 @@ on:
   pull_request:
     types: [opened, synchronize]
     paths:
-      - '.github/workflows/**'
+      - ".github/workflows/**"
   push:
     branches:
       - main
     paths:
-      - '.github/workflows/**'
+      - ".github/workflows/**"
 
 permissions: {}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,26 @@
+name: Security Analysis
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
+jobs:
+  security:
+    name: Security Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: oxc-project/security-action@fbbd523b1e765ceb174cb819b92c453bb1da265e # v1.0.0

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -430,10 +430,7 @@ fn sindresorhus_replace_comments_with_whitespace() {
     assert_eq!(strip_string("{\"a\":\"b\"/*comment*/}"), "{\"a\":\"b\"           }");
     // Note: The Rust implementation replaces newlines in block comments with spaces,
     // unlike the JavaScript version which preserves them
-    assert_eq!(
-        strip_string("{\"a\"/*\n\n\ncomment\r\n*/:\"b\"}"),
-        "{\"a\"                :\"b\"}"
-    );
+    assert_eq!(strip_string("{\"a\"/*\n\n\ncomment\r\n*/:\"b\"}"), "{\"a\"                :\"b\"}");
     // Note: Same for multi-line comments
     assert_eq!(
         strip_string("/*!\n * comment\n */\n{\"a\":\"b\"}"),
@@ -496,10 +493,7 @@ fn sindresorhus_line_endings_multi_line_block_comment() {
 
 #[test]
 fn sindresorhus_line_endings_works_at_eof() {
-    assert_eq!(
-        strip_string("{\r\n\t\"a\":\"b\"\r\n} //EOF"),
-        "{\r\n\t\"a\":\"b\"\r\n}      "
-    );
+    assert_eq!(strip_string("{\r\n\t\"a\":\"b\"\r\n} //EOF"), "{\r\n\t\"a\":\"b\"\r\n}      ");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add the canonical Security Analysis workflow using `oxc-project/security-action`
- replace legacy zizmor workflow files where present

## Testing
- Not run; workflow-only change.
