### PR TITLE
chore: update packageManager to pnpm 11.0.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,9 @@ jobs:
         with:
           save-cache: ${{ github.ref_name == 'main' }}
           cache-key: wasm
-          tools: wasm-pack@0.13.1
+
+      - name: Install wasm-pack
+        run: cargo install --locked wasm-pack --version 0.13.1
 
       - name: Check
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           save-cache: ${{ github.ref_name == 'main' }}
           cache-key: wasm
-          tools: wasm-pack
+          tools: wasm-pack@0.13.1
 
       - name: Check
         run: |

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -52,7 +52,9 @@ jobs:
         with:
           cache-key: wasm-release
           save-cache: ${{ github.ref_name == 'main' }}
-          tools: wasm-pack@0.13.1
+
+      - name: Install wasm-pack
+        run: cargo install --locked wasm-pack --version 0.13.1
 
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         with:

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           cache-key: wasm-release
           save-cache: ${{ github.ref_name == 'main' }}
-          tools: wasm-pack
+          tools: wasm-pack@0.13.1
 
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         with:

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -22,5 +22,5 @@
     "json_strip_comments_wasm_bg.wasm",
     "json_strip_comments_wasm_bg.wasm.d.ts"
   ],
-  "packageManager": "pnpm@10.33.2"
+  "packageManager": "pnpm@11.0.4"
 }


### PR DESCRIPTION
## Summary
- update the pnpm package manager pin to `pnpm@11.0.4`
- add missing pnpm package manager metadata where needed
- keep lockfiles unchanged to avoid unrelated dependency updates