### PR TITLE
chore(json-strip-comments): exclude extraneous files from published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ description = "Strip comments from JSON"
 readme = "README.md"
 repository = "https://github.com/oxc-project/json-strip-comments"
 rust-version.workspace = true
+include = ["src/lib.rs", "LICENSE", "README.md", "CHANGELOG.md", "examples/example.rs"]
 
 [[bench]]
 name    = "strip"


### PR DESCRIPTION
Adds explicit includes for `json-strip-comments` to omit 37.3 kB of files (61% of total) under `/tests`, `/benches`, and `.github` from the published package

Files removed from the package, by directory:

| Directory | Size | Files |
|---|---|---|
| `tests/**` | 16.9 kB | 1 |
| `benches/**` | 12.8 kB | 1 |
| `.github/**` | 7.4 kB | 7 |
| root config (`.clippy.toml`, `.rustfmt.toml`, `rust-toolchain.toml`, `.gitignore`) | 0.3 kB | 4 |

examples are included since they are embedded via `include_str!`

Verified with publish dry run

Found with [cargo-diet](https://github.com/the-lean-crate/cargo-diet)
