### PR TITLE
chore: reduce Rust dev debug info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,9 @@ codspeed = ["criterion2/codspeed"]
 
 [dependencies]
 memchr = "2.7.5"
+
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+debug = false


### PR DESCRIPTION
Reduces debug information for local Rust builds and disables debug information for dependencies.